### PR TITLE
feat: add createLink

### DIFF
--- a/packages/rxjs-traces/src/index.ts
+++ b/packages/rxjs-traces/src/index.ts
@@ -12,3 +12,4 @@ export {
 } from './changes';
 export { patchObservable } from './patchObservable';
 export { patchOperator } from './patchOperator';
+export { createLink } from './link';

--- a/packages/rxjs-traces/src/link.ts
+++ b/packages/rxjs-traces/src/link.ts
@@ -1,0 +1,47 @@
+import { Observable, defer } from 'rxjs';
+import { getMetadata } from './metadata';
+
+export const createLink = () => {
+  const producerEndRefs = new Set<Observable<unknown>>();
+  const consumerEndRefs = new Set<Observable<unknown>>();
+
+  const from = () => <T>(producer: Observable<T>) => {
+    producerEndRefs.add(producer);
+    consumerEndRefs.forEach((consumer) => {
+      if (getMetadata(consumer).tag === 'pre') debugger;
+      getMetadata(consumer).refs.add(producer);
+      getMetadata(producer).reverseRefs.add(consumer);
+    });
+
+    return producer;
+  };
+
+  const to = () => <T>(consumer: Observable<T>) => {
+    /**
+     * when we use `to` in this example:
+     *
+     * ```
+     *   addDebugTag('tagA')
+     *   to()
+     *   addDebugTag('tagB')
+     * ```
+     *
+     * we want tagB to have the refs comming from `from()`. This `to` operator
+     * is receiving `consumer` the result of `tagA`, so if we append the refs
+     * to that observable, we will be appending them to the wrong observable.
+     * We need to create a new reference (by using defer) and link that one
+     * instead.
+     */
+    const deferredConsumer = defer(() => consumer);
+
+    consumerEndRefs.add(deferredConsumer);
+    producerEndRefs.forEach((producer) => {
+      if (getMetadata(deferredConsumer).tag === 'pre') debugger;
+      getMetadata(deferredConsumer).refs.add(producer);
+      getMetadata(producer).reverseRefs.add(deferredConsumer);
+    });
+
+    return deferredConsumer;
+  };
+  return [from, to] as const;
+};

--- a/packages/rxjs-traces/test/link.test.ts
+++ b/packages/rxjs-traces/test/link.test.ts
@@ -1,0 +1,75 @@
+import { createLink, addDebugTag, tagValue$, patchObservable } from '../src';
+import { of, Observable } from 'rxjs';
+import { delay, takeLast, withLatestFrom, map, share } from 'rxjs/operators';
+import { restoreObservable } from '../src/patchObservable';
+import { resetTag$ } from '../src/changes';
+
+afterEach(() => {
+  resetTag$();
+});
+
+describe('createLink', () => {
+  beforeAll(() => {
+    patchObservable(Observable);
+  });
+  afterAll(() => {
+    restoreObservable(Observable);
+  });
+
+  it('bridges a gap in the pipe chain', async () => {
+    const [from, to] = createLink();
+
+    const stream = of(1).pipe(
+      delay(10),
+      addDebugTag('source'),
+      from(),
+      (source$) =>
+        new Observable((obs) => {
+          setTimeout(() => {
+            source$.subscribe(obs);
+          });
+        }),
+      to(),
+      addDebugTag('result')
+    );
+
+    const tags = await stream
+      .pipe(
+        takeLast(1),
+        withLatestFrom(tagValue$),
+        map(([_, tags]) => tags)
+      )
+      .toPromise();
+
+    expect(tags.result.refs).toEqual(['source']);
+    expect(tags.source.refs).toEqual([]);
+    const values = Object.values(tags.result.latestValues);
+    expect(values[0]).toEqual(1);
+  });
+
+  it('handles recursivity', async () => {
+    const [from, to] = createLink();
+
+    const stream = of(1).pipe(
+      addDebugTag('source'),
+      to(),
+      addDebugTag('middle'),
+      share(),
+      from(),
+      addDebugTag('result')
+    );
+
+    const tags = await stream
+      .pipe(
+        takeLast(1),
+        delay(0),
+        withLatestFrom(tagValue$),
+        map(([_, tags]) => tags)
+      )
+      .toPromise();
+
+    expect(tags.result.refs).toEqual(['middle']);
+    expect(tags.middle.refs).toEqual(['middle', 'source']);
+    expect(tags.source.refs).toEqual([]);
+  });
+});


### PR DESCRIPTION
When playing around with `createRecursiveObservable` from @josepot's rxjs-utils I found that it was a case where rxjs-traces didn't pick up the recursivity loop.

I thought on this posible solution that I think it's not too leaky. The only problem is that the test doesn't fully represent its use case, because that example could be fixed with `patchOperator`, and `link` is meant for greater distances (as when using `createRecursiveObservable`, where the source and connect are used in oposite extremes. 

A better example of its usage is by using it directly in CRO:
```js
export const recursiveObservable = () => {
  const [from, to] = createLink();
  const mirrored$ = new Subject();
  return [
    mirrored$.pipe(
      observeOn(asapScheduler),
      to(),
      share()
    ),
    () => source => source.pipe(
      tap(mirrored$),
      from()
    ),
  ];
};


const [_site$, connectSites] = recursiveObservable();
const mergedSiteResult$ = loadedDB$.pipe(
  withLatestFrom(_site$),
  map(([db, sites]) => mergeDatabase(sites, db)),
  addDebugTag("mergedSiteResult$")
);

export const [useSites, site$] = bind(
  loginDB$.pipe(
    switchMap(db => merge(upsertedSite$, mergedSiteResult$, of(db.sites))),
    addDebugTag("site$"), // Note this needs to be added before `connectSites` for the loop to make sense
    connectSites()
  )
);
```

With this the devtools are able to pick up the loop:
![image](https://user-images.githubusercontent.com/5365487/88472464-4c521f00-cf13-11ea-877b-e9ebf56ee360.png)

Note that currently `rxjs-traces` assumes that the observable is patched. Before releasing we'll need to think of an strategy regarding this.