### PR TITLE
feat: highlight changes with history slider

### DIFF
--- a/packages/devtools/src/ts/contentScripts/rxjsTraceBridge/index.ts
+++ b/packages/devtools/src/ts/contentScripts/rxjsTraceBridge/index.ts
@@ -1,7 +1,6 @@
 const requestMessages = () => {
   chrome.runtime.sendMessage({
-    type: "rxjs-traces",
-    payload: {},
+    type: "reset",
   })
   window.postMessage(
     {

--- a/packages/devtools/src/ts/devtoolsPanel/TagOverlay.tsx
+++ b/packages/devtools/src/ts/devtoolsPanel/TagOverlay.tsx
@@ -1,13 +1,17 @@
 import React, { FC, RefObject, useEffect, useRef, useState } from "react"
-import { DebugTag } from "rxjs-traces"
 import "./TagOverlay.css"
+import { connectFactoryObservable } from "react-rxjs"
+import { latestTagValue$ } from "./messaging"
+
+const [useTag] = connectFactoryObservable(latestTagValue$)
 
 export const TagOverlay: FC<{
-  tag: DebugTag
+  id: string
   initialX: number
   initialY: number
   onCopy?: (value: string) => void
-}> = ({ tag, initialX, initialY, onCopy }) => {
+}> = ({ id, initialX, initialY, onCopy }) => {
+  const tag = useTag(id)
   const ref = useRef<HTMLDivElement | null>(null)
   const drag = useDrag(ref, initialX + 15, initialY)
 
@@ -194,7 +198,6 @@ const useDrag = (
         return
       }
 
-      console.log(lastFrameUpdateMouseEvent)
       ref.current.style.left =
         positionRef.x + lastFrameUpdateMouseEvent.pageX + "px"
       ref.current.style.top =

--- a/packages/devtools/src/ts/devtoolsPanel/TimeTravelSlider.tsx
+++ b/packages/devtools/src/ts/devtoolsPanel/TimeTravelSlider.tsx
@@ -1,23 +1,22 @@
 import { FC, ChangeEvent } from "react"
 import { connectObservable } from "react-rxjs"
-import { historyLength$ } from "./messaging"
+import { historyLength$, slice$ } from "./messaging"
 import React from "react"
 import "./TimeTravelSlider.css"
 
 const [useHistoryLength] = connectObservable(historyLength$)
+const [useSlice] = connectObservable(slice$)
 
-export const TimeTravelSlider: FC<{
-  slice: number | null
-  onSliceChange: (slice: number | null) => void
-}> = ({ slice, onSliceChange }) => {
-  const max = useHistoryLength() - 1
+export const TimeTravelSlider: FC = () => {
+  const slice = useSlice()
+  const max = useHistoryLength()
 
   const handleOnChange = (evt: ChangeEvent<HTMLInputElement>) => {
     const value = Number(evt.target.value)
     if (value === max) {
-      onSliceChange(null)
+      slice$.next(null)
     } else {
-      onSliceChange(value)
+      slice$.next(value)
     }
   }
 

--- a/packages/devtools/src/ts/devtoolsPanel/index.tsx
+++ b/packages/devtools/src/ts/devtoolsPanel/index.tsx
@@ -1,16 +1,11 @@
 import * as React from "react"
-import ReactDOM from "react-dom"
-import { connectFactoryObservable } from "react-rxjs"
-import { Visualization } from "./Visualization"
 import { useState } from "react"
-import { TagOverlay } from "./TagOverlay"
+import ReactDOM from "react-dom"
 import { FilterBar } from "./FilterBar"
-import { tagValue$, copy$ } from "./messaging"
+import { copy$ } from "./messaging"
+import { TagOverlay } from "./TagOverlay"
 import { TimeTravelSlider } from "./TimeTravelSlider"
-
-const [useTagValues] = connectFactoryObservable((slice: number | null) =>
-  tagValue$(slice),
-)
+import { Visualization } from "./Visualization"
 
 interface TagSelection {
   id: string
@@ -19,8 +14,6 @@ interface TagSelection {
 }
 const App = () => {
   const [selectedTag, setSelectedTag] = useState<TagSelection | null>(null)
-  const [slice, setSlice] = useState<null | number>(null)
-  const tags = useTagValues(slice)
   const [filter, setFilter] = useState("")
 
   return (
@@ -28,19 +21,18 @@ const App = () => {
       <FilterBar filter={filter} onFilterChange={setFilter} />
       <Visualization
         filter={filter}
-        tags={tags}
         onSelectNode={(id, x, y) => setSelectedTag({ id, x, y })}
         onDeselectNode={() => setSelectedTag(null)}
       />
       {selectedTag && (
         <TagOverlay
-          tag={tags[selectedTag.id]}
+          id={selectedTag.id}
           initialX={selectedTag.x}
           initialY={selectedTag.y}
           onCopy={value => copy$.next(value)}
         />
       )}
-      <TimeTravelSlider slice={slice} onSliceChange={setSlice} />
+      <TimeTravelSlider />
     </>
   )
 }

--- a/packages/devtools/src/ts/devtoolsPanel/visualizationState.ts
+++ b/packages/devtools/src/ts/devtoolsPanel/visualizationState.ts
@@ -1,0 +1,165 @@
+import { BehaviorSubject, Subject } from "rxjs"
+import { combineLatest, debounceTime, filter, map, share } from "rxjs/operators"
+import { DataSet, EdgeOptions, NodeOptions } from "vis-network/standalone"
+import { incrementalHistory$ } from "./messaging"
+
+export const filter$ = new BehaviorSubject("")
+
+const sharedIncrementalHistory$ = incrementalHistory$.pipe(share())
+
+export const nodes = new DataSet<Node>()
+export interface Node extends NodeOptions {
+  id: string
+}
+
+const nodeColors = {
+  default: "#fc9797",
+  filterMiss: "#97c2fc",
+  highlight: "#ffb347",
+}
+
+const activeNodeWatches = new Set<string>()
+const createNodeWatch = (id: string, label: string) => {
+  if (activeNodeWatches.has(id)) {
+    return
+  }
+  activeNodeWatches.add(id)
+
+  const nodeChange$ = new Subject<Node | null>()
+
+  const activeSubscriptions = new Set<string>()
+  let isActive = false
+  const historySubscription = sharedIncrementalHistory$
+    .pipe(combineLatest(filter$))
+    .subscribe(([action, filter]) => {
+      if (action.type === "reset") {
+        nodeChange$.next(null)
+        activeSubscriptions.clear()
+        isActive = false
+        return
+      }
+
+      const historyAction = action.payload
+      const filterHit =
+        filter && label.toLocaleLowerCase().includes(filter.toLocaleLowerCase())
+      const targetColor =
+        historyAction.type == "tagValueChange$" &&
+        historyAction.payload.id === id
+          ? nodeColors.highlight
+          : filterHit
+          ? nodeColors.default
+          : nodeColors.filterMiss
+
+      if (historyAction.payload.id === id) {
+        switch (historyAction.type) {
+          case "tagValueChange$":
+          case "tagSubscription$":
+            activeSubscriptions.add(historyAction.payload.sid)
+            break
+          case "tagUnsubscription$":
+            activeSubscriptions.delete(historyAction.payload.sid)
+        }
+      }
+      if (
+        historyAction.payload.id === id ||
+        (historyAction.type === "tagRefDetection$" &&
+          historyAction.payload.ref === id)
+      ) {
+        isActive = true
+      }
+
+      if (isActive) {
+        nodeChange$.next({
+          id,
+          label,
+          color: targetColor,
+          opacity: activeSubscriptions.size === 0 ? 0.5 : 1,
+        })
+      }
+    })
+
+  const changeSubscription = nodeChange$
+    .pipe(debounceTime(0))
+    .subscribe(node => {
+      const nodeExists = nodes.get(id)
+      if (!node) {
+        if (nodeExists) {
+          nodes.remove(id)
+        }
+        historySubscription.unsubscribe()
+        changeSubscription.unsubscribe()
+        activeNodeWatches.delete(id)
+        return
+      }
+
+      if (activeSubscriptions.size > 0) {
+        if (!nodeExists) {
+          nodes.add(node)
+        } else {
+          nodes.update(node)
+        }
+      } else if (nodeExists) {
+        nodes.remove(id)
+      }
+    })
+}
+
+sharedIncrementalHistory$
+  .pipe(
+    filter(action => action.type === "incremental"),
+    map(action => (action.type === "reset" ? null! : action.payload)),
+    filter(({ type }) => type === "newTag$"),
+  )
+  .subscribe(newTag => {
+    if (newTag.type !== "newTag$") {
+      return
+    }
+    createNodeWatch(newTag.payload.id, newTag.payload.label)
+  })
+
+const edgeQtyChanges = sharedIncrementalHistory$.pipe(
+  filter(action => {
+    if (action.type === "reset") {
+      return true
+    }
+    const { type } = action.payload
+    const interestingTypes: typeof type[] = ["tagRefDetection$"]
+    return interestingTypes.includes(type)
+  }),
+  map(action => {
+    if (action.type === "reset" || action.payload.type !== "tagRefDetection$") {
+      return {
+        type: "remove-all" as const,
+      }
+    }
+    return {
+      type: "add" as const,
+      from: action.payload.payload.id,
+      to: action.payload.payload.ref,
+    }
+  }),
+)
+
+export interface Edge extends EdgeOptions {
+  id: string
+  from: string
+  to: string
+}
+export const edges = new DataSet<Edge>()
+
+edgeQtyChanges.subscribe(action => {
+  switch (action.type) {
+    case "add":
+      const { from, to } = action
+      edges.add({
+        id: `${from}->${to}`,
+        from,
+        to,
+        arrows: "from",
+      })
+      return
+    case "remove-all":
+      edges.clear()
+      return
+  }
+})


### PR DESCRIPTION
Visually there are not many changes, as it only highlights the last value:
![image](https://user-images.githubusercontent.com/5365487/89065515-2641da00-d36c-11ea-8719-1bf4b150fbef.png)

But it has changed quite a lot internally. Now the devtools, instead of merging all the actions to a state and handing this to Visualization, that component now has access to the underlying history. I think this makes it easier to detect changes between two different states.

I'm open to other posible approaches, this didn't turn out as straightforward as I initially thought.
