### PR TITLE
feat: remove tag + ref detection from history.

### DIFF
--- a/packages/devtools/src/ts/background/index.ts
+++ b/packages/devtools/src/ts/background/index.ts
@@ -1,6 +1,6 @@
-import { createTabState, ActionHistory } from "./tabState"
+import { createTabState, ActionHistory, TagState } from "./tabState"
 
-export type { ActionHistory }
+export type { ActionHistory, TagState }
 
 const tabStates = {} as Record<string, ReturnType<typeof createTabState>>
 
@@ -36,7 +36,12 @@ chrome.runtime.onConnect.addListener(function (devToolsConnection) {
     tabStates[toolsTabId] = createTabState()
   }
 
-  const subscription = tabStates[toolsTabId].actionHistory$.subscribe(
+  const tagsSub = tabStates[toolsTabId].tag$.subscribe((value) =>
+    devToolsConnection.postMessage({
+      tags: value,
+    }),
+  )
+  const actionHistorySub = tabStates[toolsTabId].actionHistory$.subscribe(
     (value: ActionHistory) =>
       devToolsConnection.postMessage({
         actionHistory: value,
@@ -62,6 +67,7 @@ chrome.runtime.onConnect.addListener(function (devToolsConnection) {
   })
 
   devToolsConnection.onDisconnect.addListener(function () {
-    subscription.unsubscribe()
+    tagsSub.unsubscribe()
+    actionHistorySub.unsubscribe()
   })
 })

--- a/packages/devtools/src/ts/devtoolsPanel/TagOverlay.tsx
+++ b/packages/devtools/src/ts/devtoolsPanel/TagOverlay.tsx
@@ -1,9 +1,23 @@
 import React, { FC, RefObject, useEffect, useRef, useState } from "react"
 import "./TagOverlay.css"
 import { connectFactoryObservable } from "react-rxjs"
-import { latestTagValue$ } from "./messaging"
+import { tagInfo$, tagValue$ } from "./messaging"
+import { combineLatest } from "rxjs"
+import { map } from "rxjs/operators"
+import { DebugTag } from "rxjs-traces"
 
-const [useTag] = connectFactoryObservable(latestTagValue$)
+const [useTag] = connectFactoryObservable((id: string) =>
+  combineLatest(tagInfo$(id), tagValue$(id)).pipe(
+    map(
+      ([info, latestValues]): DebugTag => ({
+        id: info.id,
+        label: info.label,
+        latestValues,
+        refs: info.refs,
+      }),
+    ),
+  ),
+)
 
 export const TagOverlay: FC<{
   id: string

--- a/packages/devtools/src/ts/devtoolsPanel/messaging.ts
+++ b/packages/devtools/src/ts/devtoolsPanel/messaging.ts
@@ -1,35 +1,22 @@
 import { shareLatest } from "react-rxjs"
-import {
-  BehaviorSubject,
-  combineLatest,
-  concat,
-  EMPTY,
-  from,
-  Observable,
-  of,
-  Subject,
-} from "rxjs"
-import { DebugTag } from "rxjs-traces"
-import {
-  concatMap,
-  filter,
-  map,
-  pairwise,
-  scan,
-  startWith,
-} from "rxjs/operators"
-import type { ActionHistory } from "../background"
+import { BehaviorSubject, combineLatest, Observable, Subject } from "rxjs"
+import { filter, map, scan, share, startWith } from "rxjs/operators"
+import { ActionHistory, TagState } from "../background"
 import { deserialize } from "./deserialize"
+import { incremental } from "./operators/incremental"
 
 export const copy$ = new Subject<string>()
 
-const actionHistory$ = new Observable<ActionHistory>((obs) => {
+const backgroundScriptConnection$ = new Observable<{
+  actionHistory?: ActionHistory
+  tags?: TagState
+}>((obs) => {
   var backgroundPageConnection = chrome.runtime.connect({
     name: "devtools-page_" + chrome.devtools.inspectedWindow.tabId,
   })
 
-  backgroundPageConnection.onMessage.addListener(({ actionHistory }) => {
-    obs.next(deserialize(actionHistory))
+  backgroundPageConnection.onMessage.addListener((message) => {
+    obs.next(deserialize(message))
   })
 
   const copySubscription = copy$.subscribe((payload) => {
@@ -43,86 +30,23 @@ const actionHistory$ = new Observable<ActionHistory>((obs) => {
     backgroundPageConnection.disconnect()
     copySubscription.unsubscribe()
   }
-}).pipe(startWith([]), shareLatest())
+}).pipe(share())
+
+const actionHistory$ = backgroundScriptConnection$.pipe(
+  filter((v) => Boolean(v.actionHistory)),
+  map((v) => v.actionHistory!),
+  startWith([] as ActionHistory),
+  shareLatest(),
+)
+
+export const tagState$ = backgroundScriptConnection$.pipe(
+  filter((v) => Boolean(v.tags)),
+  map((v) => v.tags!),
+  startWith({} as TagState),
+  shareLatest(),
+)
 
 type Action = ActionHistory extends Array<infer R> ? R : never
-
-const tagStateReducer = (
-  state: DebugTag | null,
-  action: Action,
-): DebugTag | null => {
-  if (action.type === "newTag$") {
-    return {
-      ...action.payload,
-      refs: [],
-      latestValues: {},
-    }
-  }
-  if (state === null) {
-    return null
-  }
-  switch (action.type) {
-    case "tagRefDetection$":
-      return {
-        ...state,
-        refs: [...state.refs, action.payload.ref],
-      }
-    case "tagSubscription$":
-      return {
-        ...state,
-        latestValues: {
-          ...state.latestValues,
-          [action.payload.sid]: undefined,
-        },
-      }
-    case "tagUnsubscription$":
-      const { [action.payload.sid]: _, ...latestValues } = state.latestValues
-      return {
-        ...state,
-        latestValues,
-      }
-    case "tagValueChange$":
-      const values = {
-        ...state.latestValues,
-      }
-      if (values[action.payload.sid] === action.payload.value) {
-        return state
-      }
-      values[action.payload.sid] = action.payload.value
-      return {
-        ...state,
-        latestValues: values,
-      }
-  }
-}
-
-const empty = Symbol("empty")
-const incremental = () => <T>(source: Observable<T[]>) =>
-  source.pipe(
-    startWith(empty),
-    pairwise(),
-    concatMap(([previous, next]) => {
-      if (!Array.isArray(next)) {
-        return EMPTY
-      }
-      const mapIncremental = map((v: T) => ({
-        type: "incremental" as const,
-        payload: v,
-      }))
-      if (previous === empty) {
-        return from(next).pipe(mapIncremental)
-      }
-      if (next.length < previous.length) {
-        return concat(
-          of({
-            type: "reset" as const,
-          }),
-          from(next).pipe(mapIncremental),
-        )
-      }
-      return from(next.slice(previous.length)).pipe(mapIncremental)
-    }),
-  )
 
 export const slice$ = new BehaviorSubject<number | null>(null)
 
@@ -133,7 +57,32 @@ export const incrementalHistory$ = combineLatest(actionHistory$, slice$).pipe(
   incremental(),
 )
 
-export const latestTagValue$ = (id: string) =>
+const tagValueReducer = (
+  state: Record<string, any>,
+  action: Action,
+): Record<string, any> => {
+  switch (action.type) {
+    case "tagSubscription$":
+      return {
+        ...state,
+        [action.payload.sid]: undefined,
+      }
+    case "tagUnsubscription$":
+      const { [action.payload.sid]: _, ...newState } = state
+      return newState
+    case "tagValueChange$":
+      if (state[action.payload.sid] === action.payload.value) {
+        return state
+      }
+      const newValues = {
+        ...state,
+        [action.payload.sid]: action.payload.value,
+      }
+      return newValues
+  }
+}
+
+export const tagValue$ = (id: string) =>
   incrementalHistory$.pipe(
     filter((action) => {
       if (action.type === "reset") {
@@ -141,7 +90,6 @@ export const latestTagValue$ = (id: string) =>
       }
       const { type, payload } = action.payload
       const interestingTypes: typeof type[] = [
-        "newTag$",
         "tagSubscription$",
         "tagUnsubscription$",
         "tagValueChange$",
@@ -150,13 +98,13 @@ export const latestTagValue$ = (id: string) =>
     }),
     scan((state, action) => {
       if (action.type === "reset") {
-        return null
+        return {}
       }
-      return tagStateReducer(state, action.payload)
-    }, null as DebugTag | null),
-    filter((v) => v !== null),
-    map((v) => v!),
+      return tagValueReducer(state, action.payload)
+    }, {} as Record<string, any>),
   )
+
+export const tagInfo$ = (id: string) => tagState$.pipe(map((v) => v[id]))
 
 export const historyLength$ = actionHistory$.pipe(
   map((history) => history.length),

--- a/packages/devtools/src/ts/devtoolsPanel/operators/incremental.ts
+++ b/packages/devtools/src/ts/devtoolsPanel/operators/incremental.ts
@@ -1,0 +1,30 @@
+import { Observable, EMPTY, from, concat, of } from "rxjs"
+import { startWith, pairwise, concatMap, map } from "rxjs/operators"
+
+const empty = Symbol("empty")
+export const incremental = () => <T>(source: Observable<T[]>) =>
+  source.pipe(
+    startWith(empty),
+    pairwise(),
+    concatMap(([previous, next]) => {
+      if (!Array.isArray(next)) {
+        return EMPTY
+      }
+      const mapIncremental = map((v: T) => ({
+        type: "incremental" as const,
+        payload: v,
+      }))
+      if (previous === empty) {
+        return from(next).pipe(mapIncremental)
+      }
+      if (next.length < previous.length) {
+        return concat(
+          of({
+            type: "reset" as const,
+          }),
+          from(next).pipe(mapIncremental),
+        )
+      }
+      return from(next.slice(previous.length)).pipe(mapIncremental)
+    }),
+  )

--- a/packages/devtools/src/ts/devtoolsPanel/operators/scanMap.ts
+++ b/packages/devtools/src/ts/devtoolsPanel/operators/scanMap.ts
@@ -1,0 +1,18 @@
+import { Observable } from "rxjs"
+import { scan, map, filter } from "rxjs/operators"
+
+const nil = Symbol("nil")
+const scanMapOperator = <S, T, R>(
+  fn: (state: S, value: T) => [S, R | typeof nil],
+  initialState: S,
+) => (source: Observable<T>) =>
+  source.pipe(
+    scan(([state], value) => fn(state, value), [initialState, nil] as [
+      S,
+      R | typeof nil,
+    ]),
+    map(([, next]) => next as R),
+    filter((v: any) => v !== nil),
+  )
+
+export const scanMap = Object.assign(scanMapOperator, { nil })


### PR DESCRIPTION
This changes makes that the history slider is based only on values and subscriptions, but not tag creations and ref detections.

That is now a separate state, which is always kept with all the tags with all references between them. Nodes still appear and disappear from the visualization based on whether they have active subscriptions.