### PR TITLE
feat: add aiding in errors (R&D)

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -3,7 +3,7 @@
   "name": "rxjs-traces-playground",
   "version": "0.1.0-alpha.1",
   "dependencies": {
-    "@react-rxjs/core": "^0.1.2",
+    "@react-rxjs/core": "0.2.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
@@ -13,6 +13,7 @@
     "@types/react-dom": "^16.9.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-error-boundary": "^2.3.1",
     "react-scripts": "3.4.1",
     "rxjs": "^6.6.0",
     "rxjs-traces": "^0.1.0-alpha.1",

--- a/packages/rxjs-traces/package.json
+++ b/packages/rxjs-traces/package.json
@@ -31,7 +31,7 @@
   "author": "Víctor Oliva",
   "module": "dist/rxjs-traces.esm.js",
   "devDependencies": {
-    "@react-rxjs/core": "^0.1.0-alpha.0",
+    "@react-rxjs/core": "0.2.0",
     "@types/uuid": "^8.0.0",
     "rxjs": "^6.6.0",
     "rxjs-for-await": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,6 +1162,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.5":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1445,15 +1452,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@react-rxjs/core@^0.1.0-alpha.0":
-  version "0.1.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@react-rxjs/core/-/core-0.1.0-alpha.0.tgz#e2ad14f60c1450337f17e033a85b9af09c564b09"
-  integrity sha512-p8/J9NUYMxVbIxO3yRoslKgF5UWIgklfAZ69cXQtMM2yafnhB9J7zHfHM1HOO9L366cZaCAK/DDfulIl5/CKww==
-
-"@react-rxjs/core@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@react-rxjs/core/-/core-0.1.2.tgz#5c2fab5500efd7ac359c00845fbdd9b7f0b70ead"
-  integrity sha512-Lztpv681KC8eT5hRj+ndVw8mPRxREAx2ZI5QBSBNfvVammERV64ZqBGaeg6mnYJp5Hr0Dv4G6QME2M+kq3J5PA==
+"@react-rxjs/core@0.2.0", "@react-rxjs/core@2.0.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@react-rxjs/core/-/core-0.2.0.tgz#3261a67d285698e64cbf167e1b5691226dfc1b61"
+  integrity sha512-95xlW/g3ccJLHmtUK8qT6BZN1pc+Hw067ZcyMAWQa1dvzGXhYKdTElQIvlDnvRG+OEjCO6yhNLqBOCy1sU9oBQ==
 
 "@rollup/plugin-commonjs@^11.0.0":
   version "11.1.0"
@@ -9980,6 +9982,13 @@ react-dom@^16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-error-boundary@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-2.3.1.tgz#bd6c8a9777224b6a1153c5f63e1ac86bf039f657"
+  integrity sha512-w1i++MM5GV6WTnM3MtLdw9CNXxqydkZwbwNDT9GBFBaWs0sp21z27DGIevb3fism1T+LGfdWgTFlhaq7G1pIMA==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
 
 react-error-overlay@^6.0.7:
   version "6.0.7"


### PR DESCRIPTION
This is something that I think it could be useful. But there's only so much we can do and this feels sooo hacky I'm considering dropping it.

Still. it's cool. It's thought for unexpected exceptions that one has in their streams. Rxjs does a good job obfuscating what went wrong... if the exception is raised in one of your functions, then you can find it in the stack trace, but if it's raised by rxjs (e.g. returning a non Observable-like in a switchMap), then it's very cryptic.

This makes 2 things:

1. Changes the name of the patched observable's next/error/complete functions to contain the debugTag (if it has any)
2. Adds the source stream that dispatched the error, so it can be studied later on if it turns out to be uncaught.

Result for the worst case (rxjs throwing an error):
![image](https://user-images.githubusercontent.com/5365487/90341169-9bb0da00-dffd-11ea-9def-49de23f8fe0f.png)

Note the warning before the browser logs the uncaught exception, and in the stacktrace you get to see the last stream that did `next`